### PR TITLE
Added dmenu bind, Add reinstall target in Makefile, Updated README.md.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
 PREFIX?=/usr/X11R6
-CFLAGS?=-Os -pedantic -Wall
+FLAGS?=-Os -pedantic -Wall
 
-all:
+install:
 	$(CC) $(CFLAGS) -I$(PREFIX)/include uwurawrxdwm.c -L$(PREFIX)/lib -lX11 -o uwurawrxdwm
+	mkdir -p /usr/local/bin
+	cp -f uwurawrxdwm /usr/local/bin/
+
+reinstall: clean
+	$(CC) $(CFLAGS) -I$(PREFIX)/include uwurawrxdwm.c -L$(PREFIX)/lib -lX11 -o uwurawrxdwm
+	mkdir -p /usr/local/bin
+	cp -f uwurawrxdwm /usr/local/bin/
 
 clean:
-	rm -f  uwurawrxdwm
-
+	rm -f uwurawrxdwm
+	rm -f /usr/local/lib/uwurawrxdwm

--- a/README.md
+++ b/README.md
@@ -22,12 +22,17 @@ Rawr, did I scare you? *giggle*
 
 Put me together:
 ```
-sudo make all
+sudo make install
 ```
 
 Tear me apart:
 ```
-sudo clean
+sudo make clean
+```
+
+Put me back together:
+```
+sudo make reinstall
 ```
 
 ## Fork me, daddy ¯`·.¸><(((º>  

--- a/uwurawrxdwm.c
+++ b/uwurawrxdwm.c
@@ -21,6 +21,8 @@ int main(void) {
         Mod1Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
     XGrabKey(display, XKeysymToKeycode(display, XStringToKeysym("a")),
         Mod1Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
+    XGrabKey(display, XKeysymToKeycode(display, XStringToKeysym("d")),
+        Mod1Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
     XGrabKey(display, XKeysymToKeycode(display, XStringToKeysym("s")),
         Mod1Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
     XGrabKey(display, XKeysymToKeycode(display, XStringToKeysym("Return")),
@@ -67,6 +69,11 @@ int main(void) {
             // Open simple terminal with mod+return
     	    if(ev.xkey.keycode == XKeysymToKeycode(display, XStringToKeysym("Return"))) {
                 system("st &");
+            }
+
+            // Open dmenu with mod+d
+    	    if(ev.xkey.keycode == XKeysymToKeycode(display, XStringToKeysym("d"))) {
+                system("dmenu_run");
             }
 
             // Close uwurawrxdwm with mod+backspace


### PR DESCRIPTION
# Hey uwu!!

* Added a binding for dmenu which is `mod+d`.
* Added a `reinstall` target in the Makefile which deletes the installed binary from `/usr/local/bin/` which should be installed by the updated `install` target.
* Updated the README.md to include the Makefile changes.